### PR TITLE
feat: Added feature ignore command

### DIFF
--- a/build/update.sh
+++ b/build/update.sh
@@ -51,6 +51,15 @@ if [ "$DRUPAL_VERSION" = 8 ]; then
     $drush cim dev --partial -y
   fi
 fi
+{
+  features_ignore_enabled_test="$($drush help fic)"
+  if [[ ${features_ignore_enabled_test} == *"Aliases: fic"* ]]; then
+    features_ignore_enabled=1
+  else
+    features_ignore_enabled=0
+  fi
+  echo "features ignore enabled: $features_ignore_enabled"
+} || {}
 if [ "$features_enabled" = 1 ]; then
   echo "Importing Features"
   $drush fra -y


### PR DESCRIPTION
Doug, according to https://stackoverflow.com/questions/15656492/linux-shell-try-catch-finally I have made my command in try catch block. So if the command  features_ignore_enabled_test="$($drush help fic)" failed, it wouldn't interrupt script execution. Hope this make sense.